### PR TITLE
Add one Boundary

### DIFF
--- a/R/bin_data.R
+++ b/R/bin_data.R
@@ -186,7 +186,7 @@ bin_data <- function(x = NULL, binCol = NULL, bins = 10, binType = "explicit", b
     binDT[, Bin := factor(Bin, levels = Bin, ordered = TRUE)]
   }else if(boundaryType == "borders_to_text"){
     binDT[, Bin := paste0(LB, "to", RB)]
-    binDT[nrow(binDT), Bin := paste0(LB, "to", RB)]
+    binDT[nrow(binDT), Bin := paste0(LB, "_to_", RB)]
     binDT[, Bin := factor(Bin, levels = Bin, ordered = TRUE)]
   } 
 

--- a/R/bin_data.R
+++ b/R/bin_data.R
@@ -184,7 +184,11 @@ bin_data <- function(x = NULL, binCol = NULL, bins = 10, binType = "explicit", b
   } else if(boundaryType == "(lorc"){
     binDT[, Bin := paste0("(", LB, ", ", RB, "]")]
     binDT[, Bin := factor(Bin, levels = Bin, ordered = TRUE)]
-  }
+  }else if(boundaryType == "borders_to_text"){
+    binDT[, Bin := paste0(LB, "to", RB)]
+    binDT[nrow(binDT), Bin := paste0(LB, "to", RB)]
+    binDT[, Bin := factor(Bin, levels = Bin, ordered = TRUE)]
+  } 
 
   #--------------------------------------------------
   # Determine the Bin for each row in dt
@@ -200,6 +204,8 @@ bin_data <- function(x = NULL, binCol = NULL, bins = 10, binType = "explicit", b
     binData[binDT, on = list(BinCol > LB, BinCol <= RB), Bin := Bin]
     binData[head(binDT, 1), on = list(BinCol >= LB, BinCol <= RB), Bin := i.Bin]
   } else if(boundaryType == "(lorc"){
+    binData[binDT, on = list(BinCol > LB, BinCol <= RB), Bin := Bin]
+  }else if(boundaryType == "borders_to_text"){
     binData[binDT, on = list(BinCol > LB, BinCol <= RB), Bin := Bin]
   }
 


### PR DESCRIPTION
I have added the to the types of boundaries created when using the `boundaryType` function. I wanted to have a boundary like `[1282.708, 48687.58]` converted to `1282.708_to_48687.58`, which is a string. Sorry, I have not taken time to read and understand the code or test my changes but you should be able to do it.