### PR TITLE
added data.table check in sparsify.R

### DIFF
--- a/R/sparsify.R
+++ b/R/sparsify.R
@@ -84,6 +84,9 @@ sparsify <- function(dt, sparsifyNAs = FALSE, naCols = "none", sparsifyCols = NU
   
   #--- Check Inputs --------------------------------------
   
+  if(!is.data.table(dt))
+    stop("dt must be a data.table object")
+  
   if(!naCols %in% c("none", "identify", "efficient")) 
     stop("Argument 'naCols' not recognized. Should be one of {\"none\", \"identify\", \"efficient\"}")
   


### PR DESCRIPTION
Hello, thank you for your work on this package!

I was using `sparsify` the other day and accidentally input a data.frame, resulting in this error message.

```
library(mltools)
sparsify(iris)
#> Error in `[.data.frame`(dt, , cols.numeric, with = FALSE): unused argument (with = FALSE)
```

so I went and added the additional check `is.data.table` to sparsify.R for a clearer error.

Ran `devtools::test()` and all was good!

Thanks again!